### PR TITLE
Updated run_metadata and timetables tables in database

### DIFF
--- a/examples/scheduler-config.yml
+++ b/examples/scheduler-config.yml
@@ -1,0 +1,42 @@
+# Example of the config file for BODSE scheduler process
+output_folder: Path to a folder to save the outputs, folder must exist
+
+task_parameters:
+  # Folder for storing the GTFS zip files, stored on the BSIP drive
+  gtfs_folder: B:\BODS GTFS Timetables
+
+  # Amount of time to download AVL data for and wait time between downloads
+  avl_download_time:
+    days: 7
+    wait_minutes: 1
+
+  # Age of timetable GTFS file before a new one will be downloaded
+  max_timetable_age_days: 7
+  # Age of AVL data before a new set is downloaded
+  max_avl_age_days: 7
+  # Age of AVL databases to be cleaned up (deleted)
+  avl_database_delete_age_days: 30
+
+# Parameters for the Postgresql database
+database_parameters:
+  username: User name for database account
+  password: Password for the database account
+  host: IP address / URL for the database
+  database: Name of the database to upload to e.g. prod or test
+  port: 5432
+
+# BODS API account details
+api_auth_config:
+  name: User name
+  password: Password
+
+# Optional URL for MS Teams channel webhook, used for posting success and error messages
+teams_webhook_url: Optional webhook URL for posting messages to a MS Teams channel
+
+# Setting for how regularly, and when, to run the process
+# Run every X months
+run_months: 1
+# Earliest day of month to run on
+run_month_day: 1
+# Days of the week when the process can be ran
+run_weekday: Monday, Tuesday, Wednesday, Thursday, Friday

--- a/src/bodse/database.py
+++ b/src/bodse/database.py
@@ -97,6 +97,9 @@ class RunMetadata(_TableBase):
     successful: orm.Mapped[bool] = orm.mapped_column(nullable=False)
     error: orm.Mapped[Optional[str]] = orm.mapped_column(nullable=True)
     output: orm.Mapped[Optional[str]] = orm.mapped_column(nullable=True)
+    time_period: orm.Mapped[Optional[str]] = orm.mapped_column(nullable=True)
+    mode: orm.Mapped[Optional[str]] = orm.mapped_column(nullable=True)
+    modelled_date: orm.Mapped[Optional[datetime.date]] = orm.mapped_column(nullable=True)
 
 
 class Timetable(_TableBase):
@@ -143,6 +146,9 @@ class Database:
         zoning_systems_id: Optional[int] = None,
         error: Optional[str] = None,
         output: Optional[str] = None,
+        time_period: Optional[str] = None,
+        mode: Optional[str] = None,
+        modelled_date: Optional[datetime.date] = None,
     ) -> int:
         """Insert run metadata into the database table.
 
@@ -162,6 +168,12 @@ class Database:
             Error message, if an error occured.
         output : str, optional
             Output message.
+        time_period : str, optional
+            Time period for the model run, if relevant.
+        mode : str, optional
+            Mode for the model run, if relevant.
+        modelled_date : datetime.date, optional
+            Date for the model run, e.g. date being modelled.
 
         Returns
         -------
@@ -189,6 +201,9 @@ class Database:
                 successful=successful,
                 error=error,
                 output=output,
+                time_period=time_period,
+                mode=mode,
+                modelled_date=modelled_date,
             )
             .returning(RunMetadata.id)
         )

--- a/src/bodse/scheduler.py
+++ b/src/bodse/scheduler.py
@@ -232,9 +232,7 @@ def get_scheduled_timetable(
         output=f"Downloaded timetable to: {path.absolute()}",
     )
     timetable_data = bsip_database.insert_timetable(
-        run_metadata_id=run_metadata_id,
-        feed_update_time=timetable.get_feed_version(path),
-        timetable_path=str(path),
+        feed_update_time=timetable.get_feed_version(path), timetable_path=str(path)
     )
 
     _log_success(
@@ -401,7 +399,6 @@ def avl_adjustment(
     db_ids = []
     for name, path in adjusted_gtfs_files.items():
         timetable_data = bsip_database.insert_timetable(
-            run_metadata_id=run_metadata_id,
             feed_update_time=timetable.get_feed_version(path),
             timetable_path=str(path),
             adjusted=True,


### PR DESCRIPTION
# Changes

- Updated metadata table to include modelled date, time period and mode as nullable columns and allowed for the intsert metadata method to handle this.
- Removed upload_date and run_metadata_id columns from timetables table and added audit columns.
- Removed unneeded columns from run_metadata table in database and updated code to match.
- Removed inserting run metadata rows for everything as they're now only used for cost metrics.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - No
- [x] Has documentation (including user guide) been updated - No
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - No
- [ ] Code linting, tests and other workflows pass
